### PR TITLE
Convert XML descriptors to YAML for XP 8

### DIFF
--- a/docs/usage.adoc
+++ b/docs/usage.adoc
@@ -89,15 +89,15 @@ This example demonstrates
 ----
 include::../src/main/resources/site/controllers/myController/myController.ts[]
 ----
-<1> relativeMappedPath must match the mapping in `site.xml` below
+<1> relativeMappedPath must match the mapping in `site.yaml` below
 <2> Defines a custom location where the controller will look for static files
 +
-. *Define the mapping* in your `site.xml` file.
+. *Define the mapping* in your `site.yaml` file.
 +
-.site/site.xml
-[source,xml]
+.site/site.yaml
+[source,yaml]
 ----
-include::../src/main/resources/site/site.xml[]
+include::../src/main/resources/site/site.yaml[]
 ----
 +
 . *Add a file* to the static files folder. In this case we place the files together with the controller:

--- a/src/main/resources/application.xml
+++ b/src/main/resources/application.xml
@@ -1,3 +1,0 @@
-<application>
-  <description>Static assets library examples</description>
-</application>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,2 @@
+kind: "Application"
+description: "Static assets library examples"

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -1,7 +1,0 @@
-<site>
-  <mappings>
-    <mapping controller="/site/controllers/myController/myController.js" order="1">
-      <pattern>/mymapping(/.*)?</pattern>
-    </mapping>
-  </mappings>
-</site>

--- a/src/main/resources/site/site.yaml
+++ b/src/main/resources/site/site.yaml
@@ -1,0 +1,5 @@
+kind: "Site"
+mappings:
+  - controller: "/site/controllers/myController/myController.js"
+    order: 1
+    pattern: "/mymapping(/.*)?"


### PR DESCRIPTION
## Summary

XP 8 expects YAML descriptors. The sample app in this repo still ships XP 7 XML form, which is misleading for readers learning the lib on XP 8.

- `src/main/resources/application.xml` → `application.yaml` (`kind: "Application"`, same `description`).
- `src/main/resources/site/site.xml` → `site/site.yaml` (`kind: "Site"`, same single mapping translated to YAML).
- `docs/usage.adoc`: the Site-mapping example's `include::` directive, source-block language, and prose references renamed from `site.xml` → `site.yaml`.

Format conversion only. Paths and contents are otherwise unchanged — controllers stay at `site/controllers/myController/myController.ts`, the mapping pattern `/mymapping(/.*)?` is preserved, no `cms/` move yet.

## Test plan

- [x] Sample app still parses as a valid XP 8 application descriptor structure (yaml shape matches the convention used across `enonic/app-*` repos: `kind: "Application"` / `kind: "Site"` with `mappings:` list).
- [ ] CI green.