### PR TITLE
Simplify AdminExtension example to use router pathParams

### DIFF
--- a/docs/usage.adoc
+++ b/docs/usage.adoc
@@ -183,7 +183,7 @@ include::../src/main/resources/admin/extensions/my-extension/my-extension.yaml[]
 ----
 include::../src/main/resources/admin/extensions/my-extension/my-extension.ts[]
 ----
-<1> Requests with the `+/_static/+` prefix are forwarded to lib-static; `+mappedRelativePath('_static')+` strips the prefix before lib-static resolves against `root`.
+<1> Requests with the `+/_static/+` prefix are forwarded to lib-static. The router pattern captures everything after `+/_static/+` into `+req.pathParams.path+`, which is handed straight to lib-static as the relative path.
 <2> The catch-all route renders the widget. Asset URLs are built relative to `request.contextPath` so they keep working under any admin mount.
 +
 . *Place a stylesheet under `src/main/resources/static/my-extension/`* — the static-asset folder the controller's `root` option points at:

--- a/src/main/resources/admin/extensions/my-extension/my-extension.ts
+++ b/src/main/resources/admin/extensions/my-extension/my-extension.ts
@@ -1,11 +1,11 @@
-import {mappedRelativePath, requestHandler} from '/lib/enonic/static';
+import {requestHandler} from '/lib/enonic/static';
 import Router from '/lib/router';
 
 const router = Router();
 
 router.get('/_static/{path:.*}', (request) => requestHandler(request, { // <1>
   root: '/static/my-extension',
-  relativePath: mappedRelativePath('_static'),
+  relativePath: (req) => req.pathParams.path,
 }));
 
 router.get('{path:.*}', (request) => ({ // <2>


### PR DESCRIPTION
## Summary

Depends on [enonic/lib-static#1011](https://github.com/enonic/lib-static/pull/1011) (closes [#1012](https://github.com/enonic/lib-static/issues/1012)), which makes `relativePath` accept a path without a leading slash. Once that lands, the AdminExtension example can drop `mappedRelativePath` entirely and hand lib-router's captured `pathParams.path` straight to lib-static:

```diff
-import {mappedRelativePath, requestHandler} from '/lib/enonic/static';
+import {requestHandler} from '/lib/enonic/static';
 import Router from '/lib/router';

 const router = Router();

 router.get('/_static/{path:.*}', (request) => requestHandler(request, {
   root: '/static/my-extension',
-  relativePath: mappedRelativePath('_static'),
+  relativePath: (req) => req.pathParams.path,
 }));
```

One less import, one less helper to reason about. The router's capture already strips the `/_static/` prefix.

The callout in `usage.adoc` is rewritten to explain how the capture flows into lib-static (instead of the previous "mappedRelativePath strips the prefix" framing).

## Don't land until

[enonic/lib-static#1011](https://github.com/enonic/lib-static/pull/1011) is merged and a SNAPSHOT with the fix is on `repo.enonic.com/dev`. Without it, `relativePath: (req) => req.pathParams.path` would silently produce wrong file lookups (paths without a leading slash currently get concatenated as `/staticstyles.css`).

## Test plan

- [x] AsciiDoc preview renders cleanly; no `mappedRelativePath` left in the AdminExtension section.
- [ ] CI green.
- [ ] After lib-static#1011 ships: real E2E in `claude-dev` confirms the simplified controller serves `/_static/styles.css` as expected.